### PR TITLE
Bump version to 1.1.0 (Prestashop 9 support) and update Google callback

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>oauthsignin</name>
     <displayName><![CDATA[Social login]]></displayName>
-    <version><![CDATA[1.0.1]]></version>
+    <version><![CDATA[1.1.0]]></version>
     <description><![CDATA[Module enabling quick login via popular providers like Google or Facebook]]></description>
     <author><![CDATA[Adam Mańko]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/config_pl.xml
+++ b/config_pl.xml
@@ -2,7 +2,7 @@
 <module>
     <name>oauthsignin</name>
     <displayName><![CDATA[Social login]]></displayName>
-    <version><![CDATA[1.0.1]]></version>
+    <version><![CDATA[1.1.0]]></version>
     <description><![CDATA[Moduł umożliwiający szybkie logowanie przez Google lub Facebooka]]></description>
     <author><![CDATA[Adam Mańko]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/oauthsignin.php
+++ b/oauthsignin.php
@@ -6,6 +6,8 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
+// require_once __DIR__ . '/vendor/autoload.php';
+
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 
 class OAuthSignIn extends Module implements WidgetInterface
@@ -14,7 +16,7 @@ class OAuthSignIn extends Module implements WidgetInterface
     {
         $this->name = 'oauthsignin';
         $this->author = 'Adam Mańko';
-        $this->version = '1.0.1';
+        $this->version = '1.1.0';
         $this->tab = 'front_office_features';
         $this->need_instance = false;
         
@@ -30,7 +32,7 @@ class OAuthSignIn extends Module implements WidgetInterface
     
         $this->ps_versions_compliancy = [
             "min" => '8.0.0.0',
-            "max" => '8.99.99'
+            "max" => '9.99.99'
         ];
     }
 

--- a/oauthsignin.php
+++ b/oauthsignin.php
@@ -6,8 +6,6 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-// require_once __DIR__ . '/vendor/autoload.php';
-
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 
 class OAuthSignIn extends Module implements WidgetInterface


### PR DESCRIPTION
Hello,

_Sidenote: Thanks for the module Maniek247! Appreciate your work._

Updated module version to 1.1.0 for Prestashop 9 support. Increased PrestaShop max version compatibility (to ^9.0). Added autoload require to Google callback controller to ensure dependencies are loaded.

I have tested it on a Prestashop 9.0 store and works well!